### PR TITLE
add missing import

### DIFF
--- a/preffs/core.py
+++ b/preffs/core.py
@@ -2,7 +2,7 @@ import pandas as pd
 
 import fsspec
 from fsspec.spec import AbstractFileSystem
-from fsspec.asyn import AsyncFileSystem
+from fsspec.asyn import AsyncFileSystem, sync
 import asyncio
 from functools import lru_cache
 


### PR DESCRIPTION
Fix for the following error:
```
File .../lib/python3.10/site-packages/preffs/core.py:238, in PRefFileSystem.cat(self, path, recursive, on_error, **kwargs)
    233                 out[p] = e
    235 elif self.get_fs(proto).async_impl:
    236     # TODO: asyncio.gather on multiple async FSs
    237     out.update(
--> 238         sync(
    239             self.loop,
    240             self._cat,
    241             paths,
    242             recursive,
    243             on_error=on_error,
    244             **kwargs,
    245         )
    246     )
    247 elif isinstance(paths, list):
    248     if recursive or any("*" in p for p in paths):

NameError: name 'sync' is not defined
```